### PR TITLE
Added makefile, pydantic

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,17 +50,17 @@ install: venv                   ## Install project in editable mode into venv
 	$(VENV_PY) -m pip install -e ".[dev]"   # grabs dev-deps if declared
 
 .PHONY: package
-package: venv clean_dist        ## Build wheel & sdist under dist/
+package: venv clean_dist        ## Builds the library as a package and puts it in dist/
 	$(VENV_PY) -m build --sdist --wheel --outdir $(DIST_DIR)
 	@echo "Built packages: $(shell ls -1 $(DIST_DIR))"
 
 .PHONY: clean_dist
-clean_dist:                     ## Remove dist/ before re-packaging
+clean_dist:                     ## only removes "extra" stuff; use before packaging
 	@rm -rf $(DIST_DIR)
 	@mkdir -p $(DIST_DIR)
 
 .PHONY: clean
-clean:                          ## Remove venv & build artifacts
+clean:                          ## Remove venv & build artifacts; useful for starting the environment fresh
 	@rm -rf $(VENV_DIR) $(DIST_DIR) *.egg-info
 
 # ─────────────────────── ADVANCED TARGETS ───────────────────

--- a/makefile
+++ b/makefile
@@ -1,0 +1,85 @@
+# ────────────────────────── CONFIG ──────────────────────────
+PYTHON := $(shell \
+    command -v python3 2>/dev/null || \
+    command -v python  2>/dev/null || \
+    command -v py      2>/dev/null )
+
+# Convert path to Windows form if we're in Git Bash
+ifeq ($(OS),Windows_NT)
+    ifneq (,$(findstring /,$(PYTHON)))
+        PYTHON := $(shell cygpath -w "$(PYTHON)")
+    endif
+endif
+
+ifeq ($(PYTHON),)
+$(error "No Python interpreter found. Install Python and ensure it's on PATH.")
+endif
+
+VENV_DIR    ?= .venv
+PKG_NAME    ?= game_contracts          # <── replace with your import-root / package dir
+DIST_DIR    ?= dist
+
+# Detect the venv’s Python & Pip once the venv exists
+VENV_PY     := $(VENV_DIR)/Scripts/python.exe
+VENV_PIP    := $(VENV_DIR)/Scripts/pip.exe
+ifeq ($(OS),Linux)
+VENV_PY     := $(VENV_DIR)/bin/python
+VENV_PIP    := $(VENV_DIR)/bin/pip
+endif
+ifeq ($(OS),Darwin)
+VENV_PY     := $(VENV_DIR)/bin/python
+VENV_PIP    := $(VENV_DIR)/bin/pip
+endif
+
+# ─────────────────────── STANDARD TARGETS ───────────────────
+
+.PHONY: help
+help:                          ## Show all commands
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS=":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: venv
+venv: $(VENV_DIR)/SUCCESS       ## Create venv (+ upgrade pip & build)
+$(VENV_DIR)/SUCCESS:
+	$(PYTHON) -m venv $(VENV_DIR)
+	$(PYTHON) -m pip install --upgrade pip build
+	@echo "done" > $@
+
+.PHONY: install
+install: venv                   ## Install project in editable mode into venv
+	$(VENV_PY) -m pip install -e ".[dev]"   # grabs dev-deps if declared
+
+.PHONY: package
+package: venv clean_dist        ## Build wheel & sdist under dist/
+	$(VENV_PY) -m build --sdist --wheel --outdir $(DIST_DIR)
+	@echo "Built packages: $(shell ls -1 $(DIST_DIR))"
+
+.PHONY: clean_dist
+clean_dist:                     ## Remove dist/ before re-packaging
+	@rm -rf $(DIST_DIR)
+	@mkdir -p $(DIST_DIR)
+
+.PHONY: clean
+clean:                          ## Remove venv & build artifacts
+	@rm -rf $(VENV_DIR) $(DIST_DIR) *.egg-info
+
+# ─────────────────────── ADVANCED TARGETS ───────────────────
+
+.PHONY: shell
+shell: venv                     ## Activate venv in a new shell
+ifeq ($(OS),Windows_NT)
+	@cmd /K "$(VENV_DIR)\Scripts\activate.bat"
+else
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && bash"
+endif
+
+.PHONY: gh-install
+gh-install:                     ## (For CI) pip-install directly from GitHub @ main
+	pip install "git+https://github.com/threnjen/$(PKG_NAME).git@main#egg=$(PKG_NAME)"
+
+.PHONY: test
+test: venv                      ## Run tests (pytest) inside venv
+	$(VENV_PY) -m pytest -q
+
+# default goal
+.DEFAULT_GOAL := help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ authors = [
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+  "pydantic>=2.11"
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/game_contracts/game_logic_interface.py
+++ b/src/game_contracts/game_logic_interface.py
@@ -1,7 +1,13 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
+from pydantic import BaseModel
+from typing import Union
 
+PydanticModelMeta = type(BaseModel)     # works for both v1 and v2
 
-class GameLogicABC(ABC):
+class ABCModelMeta(PydanticModelMeta, ABCMeta):
+    """Combine Pydantic’s and ABC’s metaclass logic."""
+
+class GameLogicABC(BaseModel, metaclass=ABCModelMeta):
     @abstractmethod
     def setup_game_state(self, game_state: dict) -> None: ...
 


### PR DESCRIPTION
Small change led to a couple bigger changes.

### Game Logic as BaseModel

Because we will want to send the game state to our clients, we'll need to quickly serialize it.  `Pydantic` accomplishes that easily.  However, from GPT:
>pydantic.BaseModel uses its own metaclass (ModelMetaclass) to register validators, build the model schema, etc. abc.ABC uses ABCMeta to enable @abstractmethod checks.

>Python won’t let a single class inherit from two bases that each bring a different metaclass unless those metaclasses have a common ancestor-relationship, so [the Union[ABC, BaseModel] attempt errors out

Hence, we have a slightly more complicated solution.

### Pydantic Install
Naturally, I needed to add it to our dependency list.

### Makefile
If you have a preferred virtual environment name (it's currently `.venv`), I don't care.  I knew I needed an editable install (`pip install -e .`), and will likely be reinstalling custom libraries.  Seemed like a good a time as any to add a makefile.

Note: could be worth pulling and ensuring this all works on MacOS.  I think it will.  Windows is the problem child:
![image](https://github.com/user-attachments/assets/6e3c0015-ecba-4ca7-ab05-ae73c16ccbfc)

This should allow for a package install from github of this package.  This isn't necessary here, but will be important when we start pulling from the game contracts repo but it's been changed.  Much easier to reinstall the package from github then open a separate VSCode, pull, and reinstall.

**Note about the makefile** If this all checks out, I don't see a reason why we can't copy/paste this makefile in all repos.