### PR TITLE
Added message class

### DIFF
--- a/src/game_contracts/message.py
+++ b/src/game_contracts/message.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, computed_field
+from enum import Enum
+from datetime import datetime, timezone  
+
+class MessageSource(str, Enum):
+    CLIENT = "client"
+    SERVER = "server"
+
+
+class Message(BaseModel):
+    player_id: str
+    source: MessageSource
+    payload: dict
+
+
+class ServerMessage(Message):
+    timestamp: datetime = datetime.now(timezone.utc)
+    source: MessageSource = MessageSource.SERVER
+
+    @computed_field
+    @property
+    def message_id(self) -> str:
+        return hash(f"{self.player_id}-{self.timestamp.isoformat()}-{self.payload}")


### PR DESCRIPTION
# Message Class

This is basically what `pydantic` was designed to do: force a schema on a payload.

We don't include a client message; the base message class is equivalent, and there are no extra fields a client might need (for now).

The timestamp and hash are done at time of receipt.

A computed field only shows up in the serialization and is not accessible as a class property (I think).  The timestamp could be a computed field, but that it gets computed when the message is serialized.

## Use

I think the app, when receiving a message, will first need to convert it to a `ServerMessage`.  This looks something like

`message = ServerMessage(message).model_dump_json()`

where `message` is the json representation of the method.

I anticipate adding a `DeliriumActionPayload(BaseModel)`.  On the client side, the payload it receives is a list of these actions.  The payload it sends is one of those actions (or the quit action).
