### PR TITLE
adds some fields to MessageEnvelope, and uses sha256 instead of hash

### DIFF
--- a/src/game_contracts/message.py
+++ b/src/game_contracts/message.py
@@ -1,6 +1,9 @@
-from pydantic import BaseModel, computed_field
-from enum import Enum
+import hashlib
+import json
 from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, Field, computed_field
 
 
 class MessageSource(str, Enum):
@@ -8,17 +11,21 @@ class MessageSource(str, Enum):
     SERVER = "server"
 
 
-class Message(BaseModel):
+class MessageEnvelope(BaseModel):
+    game_id: str
     client_id: str
     source: MessageSource
+    seq: int = 0
+    signature: str | None = None
     payload: dict
 
 
-class ServerMessage(Message):
-    timestamp: datetime = datetime.now(timezone.utc)
+class ServerMessage(MessageEnvelope):
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     source: MessageSource = MessageSource.SERVER
 
     @computed_field
     @property
-    def message_id(self) -> int:
-        return hash(f"{self.client_id}-{self.timestamp.isoformat()}-{self.payload}")
+    def message_id(self) -> str:
+        raw = f"{self.client_id}-{self.timestamp.isoformat()}-{json.dumps(self.payload, sort_keys=True)}"
+        return hashlib.sha256(raw.encode()).hexdigest()


### PR DESCRIPTION
- Adds additional fields to MessageEnvelope for the Runners to utilize
- updates from python hash() to sha256 hashing
- Makes timestamp dynamic instead of setting at message object instantiation